### PR TITLE
Add third party webdriver manager

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,28 @@
+name: pull-request
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Initialize containers
+        run: docker-compose -f docker-compose.grid.yml up -d
+
+      - name: Check available containers
+        run: docker ps
+
+      - name: Tests
+        run: |
+          mvn -B clean test -Dtest=GithubIT

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 target/
 *.iml

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Create a new mvn project and the following to your pom.xml
         <dependency>
             <groupId>com.onfido.qa.webdriver</groupId>
             <artifactId>webtest</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>0.10.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -47,18 +47,15 @@ Create a new mvn project and the following to your pom.xml
 Create your first test class in the `src/test/java` directory named `<MyTest>IT.java`.
 
 ```java
-public class GithubIT extends WebTest  {
+public class GithubIT extends WebTest {
 
-    public class FooIT extends WebTest {
+    @Test()
+    public void testGithubCodeSearch() {
+        driver().get("https://github.com/");
 
-        @Test()
-        public void testGithubCodeSearch() {
-            driver().get("https://github.com/");
-
-            verifyPage(GithubMainPage.class)
-                    .search("it-ony/webtest")
-                    .clickFirstResult();
-        }
+        verifyPage(GithubMainPage.class)
+                .search("it-ony/webtest")
+                .clickFirstResult();
     }
 }
 ```
@@ -67,7 +64,7 @@ and create the PageObjects that we want to use. The PageObject needs to extend f
 overwrite the `verifyPage` method. By doing we can make sure that we landed on the correct page.
 
 ```java
-public static class GithubMainPage extends Page {
+public class GithubMainPage extends Page {
 
     public static final By SEARCH = By.cssSelector(".header-search-input");
 
@@ -90,7 +87,7 @@ public static class GithubMainPage extends Page {
 ```
 
 ```java
-public static class GithubSearchPage extends Page {
+public class GithubSearchPage extends Page {
 
     public static final By CODE_SEARCH_RESULTS = By.cssSelector(".codesearch-results");
 

--- a/docker-compose.grid.yml
+++ b/docker-compose.grid.yml
@@ -1,0 +1,30 @@
+version: "3"
+
+services:
+
+  selenium-hub:
+    image: selenium/hub:3.141
+    container_name: selenium-hub
+    ports:
+      - "4444:4444"
+    expose:
+      - 4444
+    healthcheck:
+      test: [ "CMD", "wget", "--spider", "http://0.0.0.0:4444/wd/hub/status" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  chrome:
+    image: selenium/node-chrome:3.141
+    container_name: chrome
+    ports:
+      - "5900:5900"
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      selenium-hub:
+          condition: service_healthy
+    environment:
+      - HUB_HOST=selenium-hub
+      - HUB_PORT=4444

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.onfido.qa.webdriver</groupId>
     <artifactId>webtest</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
 
     <properties>
         <selenium-support.version>4.1.2</selenium-support.version>
@@ -97,6 +97,17 @@
             <version>${retrofit.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>5.2.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/onfido/qa/webdriver/backend/ChromeDriver.java
+++ b/src/main/java/com/onfido/qa/webdriver/backend/ChromeDriver.java
@@ -1,5 +1,6 @@
 package com.onfido.qa.webdriver.backend;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.chrome.ChromeDriverLogLevel;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.remote.service.DriverService;
@@ -8,15 +9,11 @@ import java.io.File;
 import java.util.Properties;
 import java.util.UUID;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 public class ChromeDriver implements DriverServiceFactory {
 
     @Override
     public DriverService createDriverService(Properties properties, boolean forceLog) {
-
-        var browserPath = properties.getProperty("browserPath");
-        var chromeDriverPath = properties.getProperty("chromeDriverPath");
+        WebDriverManager.chromedriver().setup();
 
         var builder = new ChromeDriverService
                 .Builder()
@@ -33,13 +30,6 @@ public class ChromeDriver implements DriverServiceFactory {
                    .withLogFile(new File(dir, UUID.randomUUID() + ".log"));
         }
 
-        if (!isEmpty(chromeDriverPath)) {
-            builder.usingDriverExecutable(new File(chromeDriverPath));
-        } else if (!isEmpty(browserPath)) {
-            builder.usingDriverExecutable(new File(browserPath));
-        }
-
         return builder.build();
-
     }
 }

--- a/src/main/java/com/onfido/qa/webdriver/backend/FirefoxDriver.java
+++ b/src/main/java/com/onfido/qa/webdriver/backend/FirefoxDriver.java
@@ -1,5 +1,6 @@
 package com.onfido.qa.webdriver.backend;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.firefox.GeckoDriverService;
 import org.openqa.selenium.remote.service.DriverService;
 
@@ -11,15 +12,10 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 public class FirefoxDriver implements DriverServiceFactory {
     @Override
     public DriverService createDriverService(Properties properties, boolean forceLog) {
+        WebDriverManager.firefoxdriver().setup();
 
         var builder = new GeckoDriverService.Builder()
                 .usingAnyFreePort();
-
-        var browserPath = properties.getProperty("geckoDriverPath");
-
-        if (!isEmpty(browserPath)) {
-            builder.usingDriverExecutable(new File(browserPath));
-        }
 
         return builder.build();
     }

--- a/src/test/java/com/onfido/qa/GithubIT.java
+++ b/src/test/java/com/onfido/qa/GithubIT.java
@@ -1,0 +1,16 @@
+package com.onfido.qa;
+
+import com.onfido.qa.github.GithubMainPage;
+import com.onfido.qa.webdriver.WebTest;
+import org.testng.annotations.Test;
+
+public class GithubIT extends WebTest {
+    @Test
+    public void testGithubCodeSearch() {
+        driver().get("https://github.com/");
+
+        verifyPage(GithubMainPage.class)
+                .search("it-ony/webtest")
+                .clickFirstResult();
+    }
+}

--- a/src/test/java/com/onfido/qa/github/GithubMainPage.java
+++ b/src/test/java/com/onfido/qa/github/GithubMainPage.java
@@ -1,0 +1,27 @@
+package com.onfido.qa.github;
+
+import com.onfido.qa.webdriver.Driver;
+import com.onfido.qa.webdriver.common.Page;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+
+public class GithubMainPage extends Page {
+
+    public static final By SEARCH = By.cssSelector(".header-search-input");
+
+    public GithubMainPage(Driver driver) {
+        super(driver);
+    }
+
+    public GithubSearchPage search(String searchTerm) {
+        driver.waitFor.clickable(SEARCH).sendKeys(searchTerm + Keys.ENTER);
+        return new GithubSearchPage(driver);
+    }
+
+    @Override
+    protected void verifyPage(Driver driver) {
+        super.verifyPage(driver);
+
+        driver.waitFor.visibility(SEARCH);
+    }
+}

--- a/src/test/java/com/onfido/qa/github/GithubSearchPage.java
+++ b/src/test/java/com/onfido/qa/github/GithubSearchPage.java
@@ -1,0 +1,27 @@
+package com.onfido.qa.github;
+
+
+import com.onfido.qa.webdriver.Driver;
+import com.onfido.qa.webdriver.common.Page;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.pagefactory.ByChained;
+
+public class GithubSearchPage extends Page {
+
+    public static final By CODE_SEARCH_RESULTS = By.cssSelector(".codesearch-results");
+
+    public GithubSearchPage(Driver driver) {
+        super(driver);
+    }
+
+    @Override
+    protected void verifyPage(Driver driver) {
+        super.verifyPage(driver);
+
+        driver.waitFor.visibility(CODE_SEARCH_RESULTS);
+    }
+
+    public void clickFirstResult() {
+        driver.waitFor.clickable(new ByChained(CODE_SEARCH_RESULTS, By.cssSelector("li a"))).click();
+    }
+}

--- a/src/test/resources/common.properties
+++ b/src/test/resources/common.properties
@@ -1,0 +1,3 @@
+local=false
+headless=false
+gridUrl=http://0.0.0.0:4444/wd/hub


### PR DESCRIPTION
### Description

* **What**—The rationale being this branch is to allow the webdriver to be managed by a third party
* **Why**—The friction of managing the webdrivers by ourselves, instead of focusing instantly on running and contributing to the test suite. Although a tiny pain, this branch solves it
* **How**—Using the [webdrivermanager](https://github.com/bonigarcia/webdrivermanager) project. Allowing us to switch from browsers, and add new ones to the library without thinking about the webdriver as a requirement, nor their versions.


This pull request also adds a smoke test to the library and makes it part of every pull request targeting the master branch ✨ 