### PR TITLE
Feature/add browserstack local folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,11 @@ Just define `browserstack.username` and `browserstack.accessKey` as system prope
 `BROWSERSTACK_ACCESS_KEY` as environment variables.
                              
 If you need to your local system from browserstack set the property `browserstack.local=true` and it will create a tunnel
-between browserstack and your system executing the tests. 
+between browserstack and your system executing the tests.
+
+If you need test resource files to use on browserstack (e.g. videos for camera injection) define `browserstack.localFolder`
+as system property or `BROWSERSTACK_LOCAL_FOLDER` as environment variable with the path to the files. The files will be
+available to download during the BrowserStack session at `http://${browserstack.username}.browserstack.com/`.
 
 The `BrowserStackListener` takes care of setting the test results. To make use of it annotate your test class 
 
@@ -266,6 +270,12 @@ To emulate a mobile device use the `@Mobile` annotation. You can define the `wid
 
 Mobile emulation is only available on chrome (and most likely on edge).
 
+# Camera Injection
+
+To use fake audio or video streams, set the property `filePathForFakeCapture` with path to fake stream files.  
+Additionally, on `@Browser` annotation:
+* Set `enableMicrophoneCameraAccess` to `true`
+* Set `fileForFakeAudioCapture` or `fileForFakeVideoCapture` to the filename
 # Switch easily between environments
 
 A best practice is to run your tests against local and testing them before the commit against a remote grid that your CI system 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/jjmluz/webtest</url>
+            <url>https://maven.pkg.github.com/it-ony/webtest</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.onfido.qa.webdriver</groupId>
     <artifactId>webtest</artifactId>
-    <version>0.9.2-SNAPSHOT</version>
+    <version>0.9.3-SNAPSHOT</version>
 
     <properties>
         <selenium-support.version>4.1.2</selenium-support.version>
@@ -17,7 +17,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/it-ony/webtest</url>
+            <url>https://maven.pkg.github.com/jjmluz/webtest</url>
         </repository>
     </distributionManagement>
 

--- a/src/main/java/com/onfido/qa/webdriver/backend/Backend.java
+++ b/src/main/java/com/onfido/qa/webdriver/backend/Backend.java
@@ -179,6 +179,7 @@ public class Backend implements Closeable {
 
         var username = properties.getProperty("browserstack.username", System.getenv("BROWSERSTACK_USERNAME"));
         var accessKey = properties.getProperty("browserstack.accessKey", System.getenv("BROWSERSTACK_ACCESS_KEY"));
+        var localFolder = properties.getProperty("browserstack.localFolder", System.getenv("BROWSERSTACK_LOCAL_FOLDER"));
 
         var enableLocalTesting = parseBoolean(Optional.ofNullable(properties.getProperty("browserstack.local", System.getenv("BROWSERSTACK_LOCAL")))
                                                       .orElse("false"));
@@ -201,6 +202,9 @@ public class Backend implements Closeable {
             map.put("key", accessKey);
             map.put("localIdentifier", id);
             map.put("binarypath", System.getenv("BROWSERSTACK_LOCAL_BINARY"));
+            if (localFolder != null) {
+                map.put("f", localFolder);
+            }
 
             local = new Local();
             local.start(map);


### PR DESCRIPTION
## Purpose

Camera stream injection on browserstack requires a bit of an hack to work. Simply passing the filepath of the injection file on our local repository doesn't work. The file has to be downloaded to the browserstack machine. I'll reach browserstack support to address this limitation. In the meantime, this PR should solve the issue.

## Approach

- Define the `filePathForFakeCapture` property to enable fake capture on different environments since `fileForFakeAudioCapture` and `fileForFakeVideoCapture` annotation has to be static. This way we may only pass the filename on the annotation and specify the path via the property.
- Use [browserstack local folder](https://www.browserstack.com/docs/automate/selenium/folder-testing) to make injection files available to download on browserstack machines.