### PR TITLE
Add allow origins capabilities to chrome driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 *.iml
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.onfido.qa.webdriver</groupId>
     <artifactId>webtest</artifactId>
-    <version>0.9.3-SNAPSHOT</version>
+    <version>0.9.4-SNAPSHOT</version>
 
     <properties>
         <selenium-support.version>4.1.2</selenium-support.version>

--- a/src/main/java/com/onfido/qa/webdriver/backend/Chrome.java
+++ b/src/main/java/com/onfido/qa/webdriver/backend/Chrome.java
@@ -32,6 +32,11 @@ class Chrome implements BrowserFactory {
         var chromeOptions = new ChromeOptions();
         var filePathForFakeCapture = properties.getProperty("filePathForFakeCapture", "./");
 
+        boolean allowOrigins = Boolean.parseBoolean(properties.getProperty("allowOrigins", "false"));
+        if (allowOrigins){
+            chromeOptions.addArguments("--remote-allow-origins=*");
+        }
+
         chromeOptions.setAcceptInsecureCerts(config.acceptInsecureCertificates);
 
         chromeOptions.setHeadless(Boolean.parseBoolean(properties.getProperty("headless", "false")));

--- a/src/main/java/com/onfido/qa/webdriver/backend/Chrome.java
+++ b/src/main/java/com/onfido/qa/webdriver/backend/Chrome.java
@@ -32,7 +32,7 @@ class Chrome implements BrowserFactory {
         var chromeOptions = new ChromeOptions();
         var filePathForFakeCapture = properties.getProperty("filePathForFakeCapture", "./");
 
-        boolean allowOrigins = Boolean.parseBoolean(properties.getProperty("allowOrigins", "false"));
+        boolean allowOrigins = Boolean.parseBoolean(properties.getProperty("remoteAllowOrigins", "false"));
         if (allowOrigins){
             chromeOptions.addArguments("--remote-allow-origins=*");
         }


### PR DESCRIPTION
On any properties file now, you can use

```
remoteAllowOrigins=true
```

That will disable CORS errors when running the tests locally.